### PR TITLE
add annotate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'web-console', '~> 2.0', group: :development
 # gem 'capistrano-rails', group: :development
 
 group :development, :test do
+  gem 'annotate'
   gem 'spring-commands-rspec'
   gem 'rspec-rails'
   gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,9 @@ GEM
       railties (>= 3.1)
       sprockets (~> 2)
       tilt
+    annotate (2.7.1)
+      activerecord (>= 3.2, < 6.0)
+      rake (>= 10.4, < 12.0)
     arel (6.0.3)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -215,6 +218,7 @@ PLATFORMS
 
 DEPENDENCIES
   angular-rails-templates
+  annotate
   byebug
   coffee-rails (~> 4.1.0)
   factory_girl_rails

--- a/app/models/education.rb
+++ b/app/models/education.rb
@@ -1,2 +1,14 @@
+# == Schema Information
+#
+# Table name: educations
+#
+#  id          :integer          not null, primary key
+#  title       :string
+#  location    :string
+#  description :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 class Education < ActiveRecord::Base
 end

--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: experiences
+#
+#  id          :integer          not null, primary key
+#  title       :string
+#  company     :string
+#  about       :string
+#  description :string
+#  start_date  :datetime
+#  end_date    :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 # {"title":"Software Engineer", "company":"Sport Ngin", "about":"At Sport Ngin, we build applications and services to help the heroes of today spend less time on the administrative activities of their organization and more time teaching the qualities of Sport to their athletes. They are our future leaders, doctors, firemen, policewomen, teachers, fathers, mothers and friends.", "description":"I am a full stack ruby on rails developer working on the content management team", "startdate":"12/1/2014", "enddate":"present"},
 # {"title":"Software Developer", "company":"C.H. Robinson", "about":"While our tradition of leadership began with our produce and truckload services, we've evolved into an industry-leading 3PL with a comprehensive portfolio of sourcing, transportation, and logistics services. The ongoing challenges of the supply chain industry inspire us to innovate and search for new ideas that challenge limits and extend Beyond Brokerage. Our customers, contract carriers, and suppliers are the beneficiaries of this forward-thinking approach, because we believe they deserve nothing but the best from their 3PL. We are not content to simply meet their expectations—we are committed to exceeding them every single day", "description":"Develop enhancements to global shipping software in an Agile environment. Architect and develop new web service, allowing company internal clients to have cleaner and more organized retrieval of system data. Leadership of implementing new practices, such as unit tests, automatic build, and code reviews resulting in much improved code quality throughout the team. Work in close collaboration with team members, project managers, architects, and business  representatives to better understand development solutions. Research and develop a prototype to explore technology options for future projects.", "startdate":"5/20/2012", "enddate":"11/15/2014"},
 # {"title":"Developer/Analyst Intern", "company":"C.H. Robinson", "about":"While our tradition of leadership began with our produce and truckload services, we've evolved into an industry-leading 3PL with a comprehensive portfolio of sourcing, transportation, and logistics services. The ongoing challenges of the supply chain industry inspire us to innovate and search for new ideas that challenge limits and extend Beyond Brokerage. Our customers, contract carriers, and suppliers are the beneficiaries of this forward-thinking approach, because we believe they deserve nothing but the best from their 3PL. We are not content to simply meet their expectations—we are committed to exceeding them every single day", "description":"Develop enhancements to global shipping software in an Agile environment. Architect and develop new web service, allowing company internal clients to have cleaner and more organized retrieval of system data. Leadership of implementing new practices, such as unit tests, automatic build, and code reviews resulting in much improved code quality throughout the team. Work in close collaboration with team members, project managers, architects, and business  representatives to better understand development solutions. Research and develop a prototype to explore technology options for future projects.", "startdate":"5/20/2011", "enddate":"8/15/2011"},

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: skills
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  level      :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 # {"name":"C#","level":"7"},
 # {"name":"VB.Net","level":"6"},
 # {"name":"Ruby","level":"4"},

--- a/spec/factories/educations.rb
+++ b/spec/factories/educations.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: educations
+#
+#  id          :integer          not null, primary key
+#  title       :string
+#  location    :string
+#  description :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 FactoryGirl.define do
   factory :education do
     title 'factory education'

--- a/spec/factories/experiences.rb
+++ b/spec/factories/experiences.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: experiences
+#
+#  id          :integer          not null, primary key
+#  title       :string
+#  company     :string
+#  about       :string
+#  description :string
+#  start_date  :datetime
+#  end_date    :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 FactoryGirl.define do
   factory :experience do
     title "MyString"

--- a/spec/factories/skills.rb
+++ b/spec/factories/skills.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: skills
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  level      :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 FactoryGirl.define do
   factory :skill do
     name "Test skill"


### PR DESCRIPTION
This adds the annotate gem. https://github.com/ctran/annotate_models .

This is really helpful because it adds the database fields as comments at the top of the model. Without this gem you have to either look in the database or look at the schema file, which is a hassle. 

```
# == Schema Info
#
# Table name: line_items
#
#  id                  :integer(11)    not null, primary key
#  quantity            :integer(11)    not null
#  product_id          :integer(11)    not null
#  unit_price          :float
#  order_id            :integer(11)
#

 class LineItem < ActiveRecord::Base
   belongs_to :product
  . . . 
```

As a part of adding models. We should remember to run `annotate` in the command line to update with these comments. 
